### PR TITLE
Fix Lowercase lettering in PMDG CDU

### DIFF
--- a/Scripts/Winwing/pmdg_777_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_777_winwing_cdu.py
@@ -138,8 +138,10 @@ def create_mobi_json(data: bytes) -> str:
                 message["Data"][dst_idx] = []
                 continue
                 
-            try:
+            try:                
                 symbol: str = chr(data[src_idx])
+                is_lowercase: bool = symbol.islower()
+                symbol = symbol.upper()
                 color: int = data[src_idx + 1]
                 flags: int = data[src_idx + 2]
 
@@ -171,7 +173,7 @@ def create_mobi_json(data: bytes) -> str:
                     message["Data"][dst_idx] = [
                         symbol,
                         color_str,
-                        1 if (flags & CDU_FLAG_SMALL_FONT) else 0
+                        1 if (is_lowercase) or (flags & CDU_FLAG_SMALL_FONT) else 0
                     ]
             except (ValueError, TypeError, IndexError) as e:
                 message["Data"][dst_idx] = []

--- a/Scripts/Winwing/pmdg_777_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_777_winwing_cdu.py
@@ -138,7 +138,7 @@ def create_mobi_json(data: bytes) -> str:
                 message["Data"][dst_idx] = []
                 continue
                 
-            try:                
+            try:
                 symbol: str = chr(data[src_idx])
                 is_lowercase: bool = symbol.islower()
                 symbol = symbol.upper()
@@ -153,7 +153,7 @@ def create_mobi_json(data: bytes) -> str:
                     elif symbol == '\xA2': symbol = "\u2192"  # right arrow
                     elif symbol == '\xA3': symbol = "\u2191"  # up arrow
                     elif symbol == '\xA4': symbol = "\u2193"  # down arrow
-                    elif symbol == '\u00EA': symbol = "\u2610"  # box
+                    elif symbol == '\u00CA': symbol = "\u2610"  # box
                     
                     # Handle color based on flags
                     if flags & CDU_FLAG_UNUSED:


### PR DESCRIPTION
Sometimes the pmdg CDU has lowercase lettering without the lowercase flag set but using actual lowercase letters. The included Font that PMDG uses seems to just use smaller uppercase letters for lowercase so there is no difference, However Mobiflight displays these as actual lowercase letters. Examples include units during weight and balance and file names during State loading.

Alternative solution would be to change the included Font.
Additionally this probably also applies to the 737 but I cannot test this.

Sorry for the stray whitespace I used the online Editor..
But since this applies to additional Files maybe just make your own commit :D